### PR TITLE
Reduce loader memory footprint while keeping targeted forwarding

### DIFF
--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -66,7 +66,7 @@ integer REFERENCE;
 key notecard_key;
 key notecard_query;
 integer reading_notecard_section;
-integer notecard_lines;
+integer notecard_lines_read;
 key reused_key;
 integer reused_variable;
 integer my_sittarget;
@@ -85,6 +85,8 @@ string onSit;
 integer speed_index;
 integer verbose = 0;
 string SEP = "�"; // OSS::string SEP = "\x7F";
+
+integer notecard_section_channel = -1;
 
 integer MSG_NOTECARD_LINE = 90310;
 integer MSG_NOTECARD_DONE = 90311;
@@ -134,18 +136,67 @@ list build_adjust_menu_items()
     return menu_items;
 }
 
-process_notecard_line(string raw_data)
+integer is_global_notecard_command(string command)
+{
+    return command == "MTYPE"
+        || command == "ROLES"
+        || command == "ETYPE"
+        || command == "SELECT"
+        || command == "WARN"
+        || command == "TEXT"
+        || command == "SWAP"
+        || command == "AMENU"
+        || command == "HELPER"
+        || command == "SET"
+        || command == "KFM"
+        || command == "LROT"
+        || command == "BRAND"
+        || command == "DFLT"
+        || command == "ONSIT"
+        || command == "ADJUST";
+}
+
+integer process_notecard_line(string raw_data)
 {
     notecard_finalized = FALSE;
     string data = llGetSubString(raw_data, llSubStringIndex(raw_data, "◆") + 1, 99999);
     data = llStringTrim(data, STRING_TRIM_HEAD);
-    string command = llGetSubString(data, 0, llSubStringIndex(data, " ") - 1);
-    list parts = llParseStringKeepNulls(llGetSubString(data, llSubStringIndex(data, " ") + 1, 99999), [" | ", " |", "| ", "|"], []);
-    string part0 = llStringTrim(llList2String(parts, 0), STRING_TRIM);
-    string part1;
-    if (llGetListLength(parts) > 1)
+    integer space_index = llSubStringIndex(data, " ");
+    string command = "";
+    list parts = [];
+    string part0 = "";
+    string part1 = "";
+    if (space_index == -1)
     {
-        part1 = llStringTrim(llDumpList2String(llList2List(parts, 1, 99999), SEP), STRING_TRIM);
+        command = data;
+    }
+    else
+    {
+        command = llGetSubString(data, 0, space_index - 1);
+        parts = llParseStringKeepNulls(llGetSubString(data, space_index + 1, 99999), [" | ", " |", "| ", "|"], []);
+        part0 = llStringTrim(llList2String(parts, 0), STRING_TRIM);
+        if (llGetListLength(parts) > 1)
+        {
+            part1 = llStringTrim(llDumpList2String(llList2List(parts, 1, 99999), SEP), STRING_TRIM);
+        }
+    }
+    if (command == "SITTER")
+    {
+        notecard_section_channel = (integer)part0;
+    }
+    integer forward_target = -1;
+    integer section_line = FALSE;
+    if (llGetSubString(data, 0, 0) == "{")
+    {
+        section_line = TRUE;
+    }
+    else if (notecard_section_channel != -1 && command != "" && command != "SITTER" && !is_global_notecard_command(command))
+    {
+        section_line = TRUE;
+    }
+    if (section_line)
+    {
+        forward_target = notecard_section_channel;
     }
     if (command == "SITTER")
     {
@@ -170,7 +221,7 @@ process_notecard_line(string raw_data)
                 SITTER_INFO = llList2List(parts, 1, 99999);
             }
         }
-        return;
+        return forward_target;
     }
     if (command == "MTYPE")
     {
@@ -180,82 +231,82 @@ process_notecard_line(string raw_data)
         {
             llPassTouches(TRUE);
         }
-        return;
+        return forward_target;
     }
     if (command == "ROLES")
     {
         RLVDesignations = (string)parts;
-        return;
+        return forward_target;
     }
     if (command == "ETYPE")
     {
         ETYPE = (integer)part0;
-        return;
+        return forward_target;
     }
     if (command == "SELECT")
     {
         SELECT = (integer)part0;
-        return;
+        return forward_target;
     }
     if (command == "WARN")
     {
         WARN = (integer)part0;
-        return;
+        return forward_target;
     }
     if (command == "TEXT")
     {
         CUSTOM_TEXT = llDumpList2String(llParseStringKeepNulls(part0, ["\\n"], []), "\n");
-        return;
+        return forward_target;
     }
     if (command == "SWAP")
     {
         SWAP = (integer)part0;
-        return;
+        return forward_target;
     }
     if (command == "AMENU")
     {
         AMENU = (integer)part0;
-        return;
+        return forward_target;
     }
     if (command == "HELPER")
     {
         OLD_HELPER_METHOD = (integer)part0;
-        return;
+        return forward_target;
     }
     if (command == "SET")
     {
         SET = (integer)part0;
-        return;
+        return forward_target;
     }
     if (command == "KFM")
     {
         HASKEYFRAME = (integer)part0;
-        return;
+        return forward_target;
     }
     if (command == "LROT")
     {
         REFERENCE = (integer)part0;
-        return;
+        return forward_target;
     }
     if (command == "BRAND")
     {
         BRAND = part0;
-        return;
+        return forward_target;
     }
     if (command == "DFLT")
     {
         DFLT = (integer)part0;
-        return;
+        return forward_target;
     }
     if (command == "ONSIT")
     {
         onSit = part0;
-        return;
+        return forward_target;
     }
     if (command == "ADJUST")
     {
         ADJUST_MENU = parts;
-        return;
+        return forward_target;
     }
     if (reading_notecard_section)
     {
@@ -318,6 +369,7 @@ process_notecard_line(string raw_data)
             }
         }
     }
+    return forward_target;
 }
 
 finalize_notecard_loading()
@@ -690,6 +742,8 @@ default
         }
         notecard_finalized = FALSE;
         is_notecard_loader = (SCRIPT_CHANNEL == 0);
+        notecard_lines_read = 0;
+        notecard_section_channel = -1;
         if (SCRIPT_CHANNEL)
         {
             memoryscript += " " + (string)SCRIPT_CHANNEL;
@@ -709,8 +763,8 @@ default
             }
             if (is_notecard_loader)
             {
-                reused_key = llGetNumberOfNotecardLines(notecard_name);
                 reading_notecard_section = TRUE;
+                llSetText("Loading...", <1,1,0>, 1);
             }
         }
         notecard_key = llGetInventoryKey(notecard_name);
@@ -896,7 +950,7 @@ default
         list data;
         if (num == MSG_NOTECARD_LINE)
         {
-            if (two != SCRIPT_CHANNEL)
+            if (!is_notecard_loader && (two == -1 || two == SCRIPT_CHANNEL))
             {
                 process_notecard_line(msg);
             }
@@ -1373,25 +1427,19 @@ default
                 }
                 return;
             }
-            if (is_notecard_loader && notecard_lines)
-            {
-                llSetText("Loading " + (string)(reused_variable * 100 / notecard_lines) + "%", <1,1,0>, 1);
-            }
             if (is_notecard_loader)
             {
+                llSetText("Loading (" + (string)(++notecard_lines_read) + " lines)", <1,1,0>, 1);
+                integer forward_target = process_notecard_line(data);
+                if (forward_target != SCRIPT_CHANNEL)
+                {
+                    llMessageLinked(LINK_SET, MSG_NOTECARD_LINE, data, (string)forward_target);
+                }
                 notecard_query = llGetNotecardLine(notecard_name, ++reused_variable);
-                llMessageLinked(LINK_SET, MSG_NOTECARD_LINE, data, (string)SCRIPT_CHANNEL);
+                return;
             }
             process_notecard_line(data);
             return;
-        }
-
-        if (query_id == reused_key)
-        {
-            if (is_notecard_loader)
-            {
-                notecard_lines = (integer)data;
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- rework notecard parsing to use locals and return the forward target so the loader no longer keeps large cached state in globals
- keep the targeted forwarding path by deriving the destination from the parsed line and broadcasting shared commands with a lightweight check
- reset the section-tracking channel when loading begins to avoid stale values when re-reading a notecard

## Testing
- not run (LSL scripts have no automated tests)


------
https://chatgpt.com/codex/tasks/task_b_68d11fd31ea48322acc12e0fa5cb93f8