### PR TITLE
Simplify speed variant detection to avoid stack collisions

### DIFF
--- a/AVsitter2/[AV]sitA.lsl
+++ b/AVsitter2/[AV]sitA.lsl
@@ -642,9 +642,35 @@ update_current_anim_name()
     list SEQUENCE = llParseStringKeepNulls(CURRENT_ANIMATION_SEQUENCE, [SEP], []);
     CURRENT_ANIMATION_FILENAME = llList2String(SEQUENCE, SEQUENCE_POINTER);
     string speed_text = llList2String(["", "+", "-"], speed_index);
-    if (llGetInventoryType(CURRENT_ANIMATION_FILENAME + speed_text) == INVENTORY_ANIMATION)
+    if (speed_text != "")
     {
-        CURRENT_ANIMATION_FILENAME += speed_text;
+        string trimmed_name = llStringTrim(CURRENT_ANIMATION_FILENAME, STRING_TRIM_TAIL);
+        string variant_name = trimmed_name + speed_text;
+        if (llGetInventoryType(variant_name) != INVENTORY_ANIMATION)
+        {
+            integer anim_total = llGetInventoryNumber(INVENTORY_ANIMATION);
+            integer variant_index;
+            while (variant_index < anim_total)
+            {
+                string inventory_name = llGetInventoryName(INVENTORY_ANIMATION, variant_index);
+                ++variant_index;
+                if (llGetSubString(inventory_name, -1, -1) == speed_text)
+                {
+                    string inventory_base = llStringTrim(llGetSubString(inventory_name, 0, -2), STRING_TRIM_TAIL);
+                    if (inventory_base == trimmed_name)
+                    {
+                        variant_name = inventory_name;
+                        jump speed_variant_found;
+                    }
+                }
+            }
+            variant_name = CURRENT_ANIMATION_FILENAME + speed_text;
+        }
+@speed_variant_found;
+        if (llGetInventoryType(variant_name) == INVENTORY_ANIMATION)
+        {
+            CURRENT_ANIMATION_FILENAME = variant_name;
+        }
     }
     llSetTimerEvent((float)llList2String(SEQUENCE, SEQUENCE_POINTER + 1));
 }

--- a/AVsitter2/[AV]sitB.lsl
+++ b/AVsitter2/[AV]sitB.lsl
@@ -112,7 +112,37 @@ integer animation_menu(integer animation_menu_function)
         {
             CURRENT_POSE_NAME = llList2String(MENU_LIST, ANIM_INDEX);
             menu += " [" + llList2String(llParseString2List(CURRENT_POSE_NAME, ["P:"], []), 0);
-            if (llGetInventoryType(animation_file + "+") == INVENTORY_ANIMATION)
+            integer has_speed_variant;
+            string trimmed_animation = llStringTrim(animation_file, STRING_TRIM_TAIL);
+            string variant_name = animation_file + "+";
+            if (llGetInventoryType(variant_name) != INVENTORY_ANIMATION)
+            {
+                variant_name = trimmed_animation + "+";
+                if (llGetInventoryType(variant_name) != INVENTORY_ANIMATION)
+                {
+                    integer anim_total = llGetInventoryNumber(INVENTORY_ANIMATION);
+                    integer variant_index;
+                    while (variant_index < anim_total)
+                    {
+                        string inventory_name = llGetInventoryName(INVENTORY_ANIMATION, variant_index);
+                        ++variant_index;
+                        string suffix = llGetSubString(inventory_name, -1, -1);
+                        if (suffix == "+" || suffix == "-")
+                        {
+                            string inventory_base = llStringTrim(llGetSubString(inventory_name, 0, -2), STRING_TRIM_TAIL);
+                            if (inventory_base == trimmed_animation)
+                            {
+                                has_speed_variant = TRUE;
+                                jump has_speed_variant_done;
+                            }
+                        }
+                    }
+                    jump has_speed_variant_done;
+                }
+            }
+            has_speed_variant = TRUE;
+@has_speed_variant_done;
+            if (has_speed_variant)
             {
                 if (speed_index < 0)
                 {


### PR DESCRIPTION
## Summary
- inline the animation speed variant resolution in [AV]sitA so spaced +/- suffixes are supported without extra helper code
- update the [AV]sitB menu to detect speed variants with trimmed comparisons, avoiding the previous helper and preserving spacing support

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_b_68d143363ff08322896b2ce154d4318d